### PR TITLE
Change Licensing to use GPL

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "docs": "jsdoc -r lib -d docs"
   },
   "author": "mereacre@gmail.com",
-  "license": "ISC",
+  "license": "GPL-3.0-or-later",
   "dependencies": {
     "babel-eslint": "^8.2.3",
     "bluebird": "^3.5.0",


### PR DESCRIPTION
ISC allows everyone to modify our code and reuse it for any purpose.
Using GPL forces them to release their own code as GPL, so that means companies would have to contact us about licensing, unless they want their own code to be GPLed as well. (Important since the source code is public on npm).

You might want to consider using some kind of NquiringMinds License, ie using it is allowed, but you can't modify it without giving us the rights to use your modifications.

I used [`license-checker`](https://www.npmjs.com/package/license-checker) to look at our code, and it seems all good. We should run this whenever we add a new npm module.

```cmd
license-checker --production --exclude 'MIT, ISC, Apache-2.0, Unlicense, BSD-3-Clause'
```