### PR TITLE
Remove eslint-plugin-json due to security concerns

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "eslint": "^3.10.2",
     "eslint-find-rules": "^1.14.3",
     "eslint-plugin-babel": "^3.2.0",
-    "eslint-plugin-json": "^1.2.0",
     "eslint-plugin-mocha": "^4.7.0",
     "eslint-plugin-node": "^3.0.4",
     "eslint-plugin-react": "^6.7.1",


### PR DESCRIPTION
The latest version of eslint-plugin-json (3 years old) depends on
an old version of jshint and therefore lodash, which has a security
bug in it: see <https://nodesecurity.io/advisories/577>.

Also moves all the eslint packages to become dev dependencies only.