### PR TITLE
Removes sqlite-helper~executeInsert()

### DIFF
--- a/lib/sqlite-helper.js
+++ b/lib/sqlite-helper.js
@@ -105,53 +105,5 @@ module.exports = (function() {
       });
     });
   };
-
-  /**
-   * Execute the sqlite db run command using the prepared statement
-   * @function
-   * @alias module:sqlite-helper.executeInsert
-   * @param {object} db - The sqlite3 db object from module node-sqlite3.
-   * @param {string} query - The sqlite query to execute
-   * @param {array[]} data - Array of arrays of data
-   * @returns {object} - The promise with a count for the total number of documents added or error
-   */
-  helper.executeInsert = function(db, query, data) {
-    return new Promise((resolve, reject) => {
-      /*
-       * db.serialize means everything in the function is done in serial, not in
-       * parallel as is normal,
-       * ie after all the db.whatever functions are called, all the callbacks
-       * are executed one after another.
-       */
-      db.serialize(() => {
-        const statement = db.prepare(query, [], (error) => {
-          if (error) {
-            reject(Error(error));
-          }
-        });
-
-        /*
-         * db.serialize only works for statements call within the function, ie
-         * none in forEach() callbacks. But since it is all in serial anyway,
-         * there is no speed slow down for the a serialized for loop.
-         */
-        for (const row of data) {
-          statement.run(row, (error) => {
-            if (error) {
-              reject(Error(error));
-            }
-          });
-        }
-
-        /*
-         * Calling finalize more than once crashes node.js, do not do this!
-         */
-        statement.finalize(() => {
-          resolve({count: data.length});
-        });
-      });
-    });
-  };
-
   return helper;
 }());

--- a/lib/sqlite-info-table.js
+++ b/lib/sqlite-info-table.js
@@ -29,12 +29,13 @@ module.exports = (function() {
   /**
    * Sets the object keys for the info table.
    * @function
+   * @async
    * @alias module:sqlite-info-table.setInfoKeys
    * @param {object} db - The sqlite3 db object from module node-sqlite3
    * @param {object[]} keys - The object keys to be save in the info table
-   * @returns {object} - The promise with the total number of keys saved or error
+   * @returns {Promise<object<string, int>>} - The count of the keys added.
    */
-  info.setInfoKeys = function(db, keys) {
+  info.setInfoKeys = async function(db, keys) {
     const data = [];
     const replaceQuery = "REPLACE INTO info (key,value) VALUES(?,?)";
 
@@ -51,7 +52,11 @@ module.exports = (function() {
         data.push(keyValuePair);
     });
 
-    return sqliteHelper.executeInsert(db, replaceQuery, data);
+    await sqliteHelper.executeMany(db, () => {
+      return replaceQuery;
+    }, data);
+    return {
+      "count": data.length};
   };
 
   /**

--- a/lib/sqlite-manager.js
+++ b/lib/sqlite-manager.js
@@ -399,13 +399,16 @@ module.exports = (function() {
   /**
    * Add data to a dataset resource.
    * @function
+   * @async
    * @alias module:sqlite-manager.addData
    * @param {object} db - The sqlite3 db object from module node-sqlite3.
    * @param {object|array} data - The data to add.
    *     Must conform to the schema defined by the resource metadata.
    *     Supports creating an individual document or many documents.
-   * @return  {object} - The promise with the total count of rows added.
+   * @return  {Promise<object<string, int>>}
+   *     - The promise with the total count of rows added.
    * @example <caption>create an individual document</caption>
+   * // returns {"count": 1} if successful
    * manager.addData(db, {lsoa: "E0000001", count: 398});
    * @example <caption>create multiple documents</caption>
    * manager.addData(db, [
@@ -414,40 +417,26 @@ module.exports = (function() {
    *  {lsoa: "E0000005", count: 4533},
    * ]);
    */
-  manager.addData = function(db, data) {
+  manager.addData = async function(db, data) {
     const schema = manager.getGeneralSchema(db);
-    const columnNames = Object.keys(schema);
-    const sqlData = [].concat(data);
-    const queryData = [];
-    let tableColumnStr = "";
-    let sqliteValue = "";
-
-    // Create the sqlite INSERT column string
-    _.forEach(columnNames, (column, idx) => {
-      tableColumnStr += column + ((idx < columnNames.length - 1) ? "," : "");
-      sqliteValue += `?${(idx < columnNames.length - 1) ? "," : ""}`;
+    const dataToConvert = [].concat(data);
+    // convert all the data to SQLite types
+    const sqlData = dataToConvert.map((row) => {
+      return sqliteConverter.convertRowToSqlite(schema, row);
     });
+    const infoTable = await sqliteInfoTable.getInfoKeys(db, ["schema"]);
+    const uniqueIndex = infoTable[0].schema.uniqueIndex;
 
-    // Iterate over all the elements and create the value string
-    _.forEach(sqlData, (element) => {
-      const row = [];
-      let transformedValue;
+    // set function for creating SQLite String, INSERT
+    const upsert = false;
+    const makeSqlStatementStr = (dataRowKeys) => {
+      return insertStatement(uniqueIndex, schema, dataRowKeys, upsert);
+    };
 
-      _.forEach(columnNames, (column) => {
-        // Convert from tdx values to sqlite values
-        if (element[column] === undefined)
-          transformedValue = sqliteConstants.SQLITE_NULL_VALUE;
-        else
-          transformedValue = sqliteConverter.convertToSqlite(schema[column], element[column], {onlyStringify: true});
-        row.push(transformedValue);
-      });
-      queryData.push(row);
-    });
-
-    const insertQuery = (
-      `INSERT INTO ${sqliteConstants.DATABASE_DATA_TABLE_NAME} (${tableColumnStr}) VALUES (${sqliteValue});`
-    );
-    return sqliteHelper.executeInsert(db, insertQuery, queryData);
+    // throws an error if it fails
+    await sqliteHelper.executeMany(db, makeSqlStatementStr,
+      sqlData);
+    return {"count": sqlData.length};
   };
 
   /**


### PR DESCRIPTION
The function `sqlite-helper~executeInsert()` is not needed, as the more general (and faster) `sqlite-helper~executeMany()` works instead.

All tests pass (and I believe the tests are faster as well, but it might just be random chance).