### PR TITLE
Fix singleton bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,11 @@ The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### MAJOR
+
+- Changes `getGeneralSchema()` to return a `Promise`.
+  This fixes a bug in which database objects would crash if module caching did
+  not work, see #32.

--- a/lib/sqlite-info-table.js
+++ b/lib/sqlite-info-table.js
@@ -4,120 +4,113 @@
  * @author Alexandru Mereacre <mereacre@gmail.com>
  */
 
-exports.createInfoTable
+"use strict";
 
-module.exports = (function() {
-  "use strict";
+const sqliteConstants = require("./sqlite-constants.js");
+const sqliteConverter = require("./sqlite-schema-converter.js");
+const sqliteHelper = require("./sqlite-helper.js");
 
-  const sqliteConstants = require("./sqlite-constants.js");
-  const sqliteConverter = require("./sqlite-schema-converter.js");
-  const sqliteHelper = require("./sqlite-helper.js");
+/**
+ * Creates the info table.
+ * @function
+ * @alias module:sqlite-info-table.createInfoTable
+ * @param {object} db - The sqlite3 db object from module node-sqlite3
+ * @returns {object} - The error promise
+ */
+exports.createInfoTable = function(db) {
+  return db.runAsync(
+    `CREATE TABLE ${sqliteConstants.DATABASE_INFO_TABLE_NAME} (key text PRIMARY KEY,value text);`, []);
+};
 
-  const info = {};
+/**
+ * Sets the object keys for the info table.
+ * @function
+ * @alias module:sqlite-info-table.setInfoKeys
+ * @param {object} db - The sqlite3 db object from module node-sqlite3
+ * @param {Object<string, any>[]} keys
+ *   The object keys to be save in the info table
+ * @returns {Promise<{count: number}>} - The count of the keys added.
+ */
+exports.setInfoKeys = async function(db, keys) {
+  const data = [];
+  const replaceQuery = "REPLACE INTO info (key,value) VALUES(?,?)";
 
-  /**
-   * Creates the info table.
-   * @function
-   * @alias module:sqlite-info-table.createInfoTable
-   * @param {object} db - The sqlite3 db object from module node-sqlite3
-   * @returns {object} - The error promise
-   */
-  info.createInfoTable = function(db) {
-    return db.runAsync(
-      `CREATE TABLE ${sqliteConstants.DATABASE_INFO_TABLE_NAME} (key text PRIMARY KEY,value text);`, []);
-  };
+  keys.forEach((valueInfo) => {
+    let keyValuePair = [];
+    for (const [key, value] of Object.entries(valueInfo)) {
+      const sqlValidKey = sqliteConverter.convertToSqlite(
+        sqliteConstants.SQLITE_TYPE_TEXT, key, {onlyStringify: true});
+      const sqlValidValue = sqliteConverter.convertToSqlite(
+        sqliteConstants.SQLITE_GENERAL_TYPE_OBJECT, value, {onlyStringify: true});
 
-  /**
-   * Sets the object keys for the info table.
-   * @function
-   * @alias module:sqlite-info-table.setInfoKeys
-   * @param {object} db - The sqlite3 db object from module node-sqlite3
-   * @param {Object<string, any>[]} keys
-   *   The object keys to be save in the info table
-   * @returns {Promise<{count: number}>} - The count of the keys added.
-   */
-  info.setInfoKeys = async function(db, keys) {
-    const data = [];
-    const replaceQuery = "REPLACE INTO info (key,value) VALUES(?,?)";
-
-    keys.forEach((valueInfo) => {
-      let keyValuePair = [];
-      for (const [key, value] of Object.entries(valueInfo)) {
-        const sqlValidKey = sqliteConverter.convertToSqlite(
-          sqliteConstants.SQLITE_TYPE_TEXT, key, {onlyStringify: true});
-        const sqlValidValue = sqliteConverter.convertToSqlite(
-          sqliteConstants.SQLITE_GENERAL_TYPE_OBJECT, value, {onlyStringify: true});
-
-        keyValuePair = [sqlValidKey, sqlValidValue];
-      }
-
-      if (keyValuePair.length)
-        data.push(keyValuePair);
-    });
-
-    await sqliteHelper.executeMany(db, () => {
-      return replaceQuery;
-    }, data);
-    return {
-      "count": data.length};
-  };
-
-  /**
-   * Returns the object keys for the info table.
-   * @function
-   * @alias module:sqlite-info-table.getInfoKeys
-   * @param {object} db - The sqlite3 db object from module node-sqlite3
-   * @param {string[]} keys - The named keys to be retrieved from the info table
-   * @returns {Promise<object[]>}
-   *   The promise with array of pairs of key/value or error
-   */
-  info.getInfoKeys = async function(db, keys) {
-    const selectQuery = "SELECT key,value FROM info WHERE ";
-    /** @type {Object<string, any>[]} */
-    const keyValuePairs = [];
-    const queryData = [];
-    let whereQuery = "";
-
-    keys.forEach((key, idx) => {
-      if (key !== "") {
-        const orProp = (idx < keys.length - 1) ? " OR " : ";";
-        const sqlValidKey = sqliteConverter.convertToSqlite(
-          sqliteConstants.SQLITE_TYPE_TEXT, key, {onlyStringify: true});
-        whereQuery += `key=?${orProp}`;
-
-        queryData.push(sqlValidKey);
-      }
-    });
-
-    if (whereQuery === "") {
-      // keys is empty. Shouldn't we raise an error in this case?
-      return keyValuePairs;
+      keyValuePair = [sqlValidKey, sqlValidValue];
     }
 
-    const rows = await db.allAsync(selectQuery + whereQuery, queryData);
-    rows.forEach(({key, value}) => {
-      const keyValue = {};
-      keyValue[key] = sqliteConverter.convertToTdx(
-        sqliteConstants.SQLITE_GENERAL_TYPE_OBJECT, value);
-      keyValuePairs.push(keyValue);
-    });
+    if (keyValuePair.length)
+      data.push(keyValuePair);
+  });
 
+  await sqliteHelper.executeMany(db, () => {
+    return replaceQuery;
+  }, data);
+  return {
+    "count": data.length};
+};
+
+/**
+ * Returns the object keys for the info table.
+ * @function
+ * @alias module:sqlite-info-table.getInfoKeys
+ * @param {object} db - The sqlite3 db object from module node-sqlite3
+ * @param {string[]} keys - The named keys to be retrieved from the info table
+ * @returns {Promise<object[]>}
+ *   The promise with array of pairs of key/value or error
+ */
+exports.getInfoKeys = async function(db, keys) {
+  const selectQuery = "SELECT key,value FROM info WHERE ";
+  /** @type {Object<string, any>[]} */
+  const keyValuePairs = [];
+  const queryData = [];
+  let whereQuery = "";
+
+  keys.forEach((key, idx) => {
+    if (key !== "") {
+      const orProp = (idx < keys.length - 1) ? " OR " : ";";
+      const sqlValidKey = sqliteConverter.convertToSqlite(
+        sqliteConstants.SQLITE_TYPE_TEXT, key, {onlyStringify: true});
+      whereQuery += `key=?${orProp}`;
+
+      queryData.push(sqlValidKey);
+    }
+  });
+
+  if (whereQuery === "") {
+    // keys is empty. Shouldn't we raise an error in this case?
     return keyValuePairs;
-  };
+  }
 
-  /**
-   * Checks if info table exists.
-   * @function
-   * @alias module:sqlite-info-table.checkInfoTable
-   * @param {object} db - The sqlite3 db object from module node-sqlite3
-   * @returns {Promise<boolean>} - The promise with true or false
-   */
-  info.checkInfoTable = async function(db) {
-    const rows = await db.allAsync(
-      "SELECT name FROM sqlite_master WHERE type='table'", []);
-    const search = rows.find((x) => x.name === sqliteConstants.DATABASE_INFO_TABLE_NAME);
-    return search !== undefined;
-  };
+  const rows = await db.allAsync(selectQuery + whereQuery, queryData);
+  rows.forEach(({key, value}) => {
+    const keyValue = {};
+    keyValue[key] = sqliteConverter.convertToTdx(
+      sqliteConstants.SQLITE_GENERAL_TYPE_OBJECT, value);
+    keyValuePairs.push(keyValue);
+  });
 
-  return info;
-}());
+  return keyValuePairs;
+};
+
+/**
+ * Checks if info table exists.
+ * @function
+ * @alias module:sqlite-info-table.checkInfoTable
+ * @param {object} db - The sqlite3 db object from module node-sqlite3
+ * @returns {Promise<boolean>} - The promise with true or false
+ */
+exports.checkInfoTable = async function(db) {
+  const rows = await db.allAsync(
+    "SELECT name FROM sqlite_master WHERE type='table'", []);
+  const search = rows.find(
+    (x) => x.name === sqliteConstants.DATABASE_INFO_TABLE_NAME);
+  return search !== undefined;
+};

--- a/lib/sqlite-info-table.js
+++ b/lib/sqlite-info-table.js
@@ -4,11 +4,11 @@
  * @author Alexandru Mereacre <mereacre@gmail.com>
  */
 
+exports.createInfoTable
+
 module.exports = (function() {
   "use strict";
 
-  const _ = require("lodash");
-  const Promise = require("bluebird");
   const sqliteConstants = require("./sqlite-constants.js");
   const sqliteConverter = require("./sqlite-schema-converter.js");
   const sqliteHelper = require("./sqlite-helper.js");
@@ -23,30 +23,33 @@ module.exports = (function() {
    * @returns {object} - The error promise
    */
   info.createInfoTable = function(db) {
-    return db.runAsync(`CREATE TABLE ${sqliteConstants.DATABASE_INFO_TABLE_NAME} (key text PRIMARY KEY,value text);`, []);
+    return db.runAsync(
+      `CREATE TABLE ${sqliteConstants.DATABASE_INFO_TABLE_NAME} (key text PRIMARY KEY,value text);`, []);
   };
 
   /**
    * Sets the object keys for the info table.
    * @function
-   * @async
    * @alias module:sqlite-info-table.setInfoKeys
    * @param {object} db - The sqlite3 db object from module node-sqlite3
-   * @param {object[]} keys - The object keys to be save in the info table
-   * @returns {Promise<object<string, int>>} - The count of the keys added.
+   * @param {Object<string, any>[]} keys
+   *   The object keys to be save in the info table
+   * @returns {Promise<{count: number}>} - The count of the keys added.
    */
   info.setInfoKeys = async function(db, keys) {
     const data = [];
     const replaceQuery = "REPLACE INTO info (key,value) VALUES(?,?)";
 
-    _.forEach(keys, (valueInfo) => {
+    keys.forEach((valueInfo) => {
       let keyValuePair = [];
-      _.forEach(valueInfo, (value, key) => {
-        const sqlValidKey = sqliteConverter.convertToSqlite(sqliteConstants.SQLITE_TYPE_TEXT, key, {onlyStringify: true});
-        const sqlValidValue = sqliteConverter.convertToSqlite(sqliteConstants.SQLITE_GENERAL_TYPE_OBJECT, value, {onlyStringify: true});
+      for (const [key, value] of Object.entries(valueInfo)) {
+        const sqlValidKey = sqliteConverter.convertToSqlite(
+          sqliteConstants.SQLITE_TYPE_TEXT, key, {onlyStringify: true});
+        const sqlValidValue = sqliteConverter.convertToSqlite(
+          sqliteConstants.SQLITE_GENERAL_TYPE_OBJECT, value, {onlyStringify: true});
 
         keyValuePair = [sqlValidKey, sqlValidValue];
-      });
+      }
 
       if (keyValuePair.length)
         data.push(keyValuePair);
@@ -65,39 +68,41 @@ module.exports = (function() {
    * @alias module:sqlite-info-table.getInfoKeys
    * @param {object} db - The sqlite3 db object from module node-sqlite3
    * @param {string[]} keys - The named keys to be retrieved from the info table
-   * @returns {object[]} - The promise with array of pairs of key/value or error
+   * @returns {Promise<object[]>}
+   *   The promise with array of pairs of key/value or error
    */
-  info.getInfoKeys = function(db, keys) {
+  info.getInfoKeys = async function(db, keys) {
     const selectQuery = "SELECT key,value FROM info WHERE ";
+    /** @type {Object<string, any>[]} */
     const keyValuePairs = [];
     const queryData = [];
     let whereQuery = "";
 
-    _.forEach(keys, (key, idx) => {
+    keys.forEach((key, idx) => {
       if (key !== "") {
         const orProp = (idx < keys.length - 1) ? " OR " : ";";
-        const sqlValidKey = sqliteConverter.convertToSqlite(sqliteConstants.SQLITE_TYPE_TEXT, key, {onlyStringify: true});
+        const sqlValidKey = sqliteConverter.convertToSqlite(
+          sqliteConstants.SQLITE_TYPE_TEXT, key, {onlyStringify: true});
         whereQuery += `key=?${orProp}`;
 
         queryData.push(sqlValidKey);
       }
     });
 
-    if (whereQuery !== "") {
-      return db.allAsync(selectQuery + whereQuery, queryData)
-        .then((rows) => {
-          _.forEach(rows, (pairObject) => {
-            const keyValue = {};
-            keyValue[pairObject.key] = sqliteConverter.convertToTdx(sqliteConstants.SQLITE_GENERAL_TYPE_OBJECT, pairObject.value);
-            keyValuePairs.push(keyValue);
-          });
-
-          return Promise.resolve(keyValuePairs);
-        });
+    if (whereQuery === "") {
+      // keys is empty. Shouldn't we raise an error in this case?
+      return keyValuePairs;
     }
 
-    // @ts-ignore
-    return Promise.resolve(keyValuePairs);
+    const rows = await db.allAsync(selectQuery + whereQuery, queryData);
+    rows.forEach(({key, value}) => {
+      const keyValue = {};
+      keyValue[key] = sqliteConverter.convertToTdx(
+        sqliteConstants.SQLITE_GENERAL_TYPE_OBJECT, value);
+      keyValuePairs.push(keyValue);
+    });
+
+    return keyValuePairs;
   };
 
   /**
@@ -105,16 +110,13 @@ module.exports = (function() {
    * @function
    * @alias module:sqlite-info-table.checkInfoTable
    * @param {object} db - The sqlite3 db object from module node-sqlite3
-   * @returns {object} - The promise with true or false
+   * @returns {Promise<boolean>} - The promise with true or false
    */
-  info.checkInfoTable = function(db) {
-    return db.allAsync("SELECT name FROM sqlite_master WHERE type='table'", [])
-      .then((rows) => {
-        const search = _.find(rows, {"name": sqliteConstants.DATABASE_INFO_TABLE_NAME});
-        if (search === undefined)
-          return Promise.resolve(false);
-        else return Promise.resolve(true);
-      });
+  info.checkInfoTable = async function(db) {
+    const rows = await db.allAsync(
+      "SELECT name FROM sqlite_master WHERE type='table'", []);
+    const search = rows.find((x) => x.name === sqliteConstants.DATABASE_INFO_TABLE_NAME);
+    return search !== undefined;
   };
 
   return info;

--- a/lib/sqlite-manager.js
+++ b/lib/sqlite-manager.js
@@ -437,7 +437,7 @@ module.exports = (function() {
    * @function
    * @alias module:sqlite-manager.getGeneralSchema
    * @param {object} db - The sqlite3 db object from module node-sqlite3.
-   * @returns {object} - The general schema object
+   * @returns {object | Promise<object>} - The general schema object
    */
   manager.getGeneralSchema = function(db) {
     return generalSchema[db.id];

--- a/lib/sqlite-manager.js
+++ b/lib/sqlite-manager.js
@@ -229,28 +229,6 @@ module.exports = (function() {
     // Generate an id to store the general schema in the dictionary
     db.id = shortid.generate();
 
-    // Check if info table exists (the dataset might not be created yet)
-    const tableExists = await sqliteInfoTable.checkInfoTable(db);
-
-    let generalSchema = {};
-    // Get the tdx schema definition
-    if (tableExists) {
-      const tdxSchema = await sqliteInfoTable.getInfoKeys(db, ["schema"]);
-
-      if (tdxSchema.length) {
-        // Dataset schema definition
-        tdxSchema[0].schema = tdxSchema[0].schema || {};
-
-        // Dataset data schema
-        tdxSchema[0].schema.dataSchema = tdxSchema[0].schema.dataSchema || {};
-
-        generalSchema = await sqliteConverter.convertSchema(
-          tdxSchema[0].schema.dataSchema);
-      }
-    }
-    // Assign the general schema if the info table exists and the dataset exists
-    // Will be empty otherwise
-    await setGeneralSchema(db, generalSchema);
     return db;
   };
 
@@ -266,9 +244,7 @@ module.exports = (function() {
       db.close((error) => {
         if (error) reject(error);
         else {
-          // Clean the general schema
-          setGeneralSchema(db, {});
-          resolve({});
+          resolve();
         }
       });
     });
@@ -349,10 +325,6 @@ module.exports = (function() {
       // throw early if there's a unique index but no schema
       throw Error("[sqlite-manager]: index doesn't match schema.");
 
-    // Convert from tdx to a general sqlite schema
-    // Assign to general schema
-    setGeneralSchema(db, sqliteConverter.convertSchema(options.schema.dataSchema));
-
     const infoExists = await sqliteInfoTable.checkInfoTable(db);
     if (infoExists) {
       // Check if schema match
@@ -371,7 +343,7 @@ module.exports = (function() {
       }
     } else {
       // create a new info table
-      sqliteInfoTable.createInfoTable(db);
+      await sqliteInfoTable.createInfoTable(db);
       await sqliteInfoTable.setInfoKeys(db, _.map(options, (value, key) => {
         const pair = {};
         pair[key] = value;
@@ -380,7 +352,7 @@ module.exports = (function() {
 
       // Map the converted schema to a valid sqlite schema and then
       // map it to a string
-      const schema = manager.getGeneralSchema(db);
+      const schema = await manager.getGeneralSchema(db);
       const sqliteSchemaKeys = _.map(
         sqliteConverter.mapSchema(schema),
         (value, key) => `${key} ${value}`
@@ -437,10 +409,32 @@ module.exports = (function() {
    * @function
    * @alias module:sqlite-manager.getGeneralSchema
    * @param {object} db - The sqlite3 db object from module node-sqlite3.
-   * @returns {object | Promise<object>} - The general schema object
+   * @returns {Promise<object>} - The general schema object
    */
-  manager.getGeneralSchema = function(db) {
-    return generalSchema[db.id];
+  manager.getGeneralSchema = async function(db) {
+    const cachedGeneralSchema = db.generalSchema;
+    if (cachedGeneralSchema) {
+      return cachedGeneralSchema;
+    }
+    const tdxSchema = await sqliteInfoTable.getInfoKeys(db, ["schema"]);
+
+    let thisGeneralSchema = {};
+
+    if (tdxSchema.length) {
+      // Dataset schema definition
+      tdxSchema[0].schema = tdxSchema[0].schema || {};
+
+      // Dataset data schema
+      tdxSchema[0].schema.dataSchema = tdxSchema[0].schema.dataSchema || {};
+
+      thisGeneralSchema = await sqliteConverter.convertSchema(
+        tdxSchema[0].schema.dataSchema);
+
+      // Assign the general schema if the info table exists and the dataset exists
+      // Will be empty otherwise
+      db.generalSchema = thisGeneralSchema;
+    }
+    return thisGeneralSchema;
   };
 
   /**
@@ -468,7 +462,7 @@ module.exports = (function() {
    * manager.addData(db, {id: 1, array: manager.getNdarrayMeta(buffer, "float64", [23, 34])});
    */
   manager.addData = async function(db, data) {
-    const schema = manager.getGeneralSchema(db);
+    const schema = await manager.getGeneralSchema(db);
     const dataToConvert = [].concat(data);
 
     // Get the ndarray keys
@@ -619,7 +613,7 @@ module.exports = (function() {
     if (!_.isEmpty(sortQuery)) selectQuery.order = sortQuery;
 
     // Set the projection columns
-    const schema = manager.getGeneralSchema(db);
+    const schema = await manager.getGeneralSchema(db);
     const excludedColumns = Object.keys(schema);
     const includedColumns = [];
     _.forEach(projection, (value, key) => {
@@ -748,7 +742,7 @@ module.exports = (function() {
       set_throws = true;
     }
 
-    const schema = manager.getGeneralSchema(db);
+    const schema = await manager.getGeneralSchema(db);
     const dataToConvert = [].concat(data);
     const sqlData = dataToConvert.map((row) => {
       return sqliteConverter.convertRowToSqlite(schema, row);
@@ -906,7 +900,7 @@ module.exports = (function() {
       throw Error(
         "doNotThrow is currently unimplemented, just try/catch your code");
     }
-    const schema = manager.getGeneralSchema(db);
+    const schema = await manager.getGeneralSchema(db);
     const dataToConvert = [].concat(data); // make sure data is an array
     const sqlData = dataToConvert.map((row) => {
       return sqliteConverter.convertRowToSqlite(schema, row);
@@ -1003,17 +997,6 @@ module.exports = (function() {
     });
     return resource;
   };
-
-  /**
-   * Sets the general schema and the default NULL array.
-   * @function
-   * @alias module:sqlite-manager.setGeneralSchema
-   * @param {object} db - The sqlite3 db object from module node-sqlite3.
-   * @param {object} schema - The general schema.
-   */
-  function setGeneralSchema(db, schema) {
-    generalSchema[db.id] = schema;
-  }
 
   /**
    * Returns the ndarray metadata

--- a/test/test-sqlite-manager.js
+++ b/test/test-sqlite-manager.js
@@ -143,38 +143,22 @@ describe("sqlite-manager", function() {
           return sqLiteManager.openDatabase(databasePath, "file", "r");
         })
         .then((db) => {
-          return Promise.resolve(sqLiteManager.getGeneralSchema(db));
+          return sqLiteManager.getGeneralSchema(db);
         })
         .should.eventually.deep.equal(tdxSchemaList.TDX_SCHEMA_LIST[0].generalSchema);
     });
   });
 
   describe("createDataset", function() {
-    before("Create the dataset object", function(done) {
-      sqLiteManager.openDatabase("", "memory", "w+")
-        .then((db) => {
-          dbMem = db;
-          done();
-        })
-        .catch((error) => {
-          done(error);
-        });
+    beforeEach("Create the dataset object", async () => {
+      dbMem = await sqLiteManager.openDatabase("", "memory", "w+");
     });
 
-    beforeEach("Delete the info and data tables", function(done) {
-      dbMem.runAsync(`DROP TABLE IF EXISTS ${sqliteConstants.DATABASE_INFO_TABLE_NAME};`, [])
-        .then(() => {
-          return dbMem.runAsync(`DROP TABLE IF EXISTS ${sqliteConstants.DATABASE_DATA_TABLE_NAME};`, []);
-        })
-        .then(() => {
-          return dbMem.runAsync(`DROP INDEX IF EXISTS ${sqliteConstants.DATABASE_TABLE_INDEX_NAME};`, []);
-        })
-        .then(() => {
-          done();
-        })
-        .catch((error) => {
-          done(error);
-        });
+    afterEach("Close the dataset object", async () => {
+      if (dbMem) {
+        await dbMem.close();
+        dbMem = null;
+      }
     });
 
     it("should succeed if database empty", function() {
@@ -279,43 +263,36 @@ describe("sqlite-manager", function() {
           dbFirst = db;
           return sqLiteManager.createDataset(dbFirst, entryFirst);
         })
-        .then(() => {
-          generalSchemaFirst = _.cloneDeep(sqLiteManager.getGeneralSchema(dbFirst));
+        .then(async () => {
+          generalSchemaFirst = _.cloneDeep(
+            await sqLiteManager.getGeneralSchema(dbFirst));
           return sqLiteManager.openDatabase("", "memory", "w+");
         })
         .then((db) => {
           return sqLiteManager.createDataset(db, entrySecond);
         })
-        .then(() => {
-          return Promise.resolve(_.isEqual(generalSchemaFirst, sqLiteManager.getGeneralSchema(dbFirst)));
+        .then(async () => {
+          return Promise.resolve(_.isEqual(generalSchemaFirst,
+            await sqLiteManager.getGeneralSchema(dbFirst)));
         })
         .should.eventually.equal(true);
     });
 
-    it("should close only one database when opening two and closing one", function() {
+    it("should close only one database when opening two and closing one", async () => {
       const entryFirst = tdxSchemaList.TDX_SCHEMA_LIST[0];
       const entrySecond = tdxSchemaList.TDX_SCHEMA_LIST[1];
-      let dbFirst;
-      let dbSecond;
-      return sqLiteManager.openDatabase("", "memory", "w+")
-        .then((db) => {
-          dbFirst = db;
-          return sqLiteManager.createDataset(dbFirst, entryFirst);
-        })
-        .then(() => {
-          return sqLiteManager.openDatabase("", "memory", "w+");
-        })
-        .then((db) => {
-          dbSecond = db;
-          return sqLiteManager.createDataset(db, entrySecond);
-        })
-        .then(() => {
-          return sqLiteManager.closeDatabase(dbSecond);
-        })
-        .then(() => {
-          return Promise.resolve(_.isEmpty(sqLiteManager.getGeneralSchema(dbSecond)) && !_.isEmpty(sqLiteManager.getGeneralSchema(dbFirst)));
-        })
-        .should.eventually.equal(true);
+      const dbFirst = await sqLiteManager.openDatabase("", "memory", "w+");
+      await sqLiteManager.createDataset(dbFirst, entryFirst);
+      const dbSecond = await sqLiteManager.openDatabase("", "memory", "w+");
+      await sqLiteManager.createDataset(dbSecond, entrySecond);
+
+      await sqLiteManager.closeDatabase(dbSecond);
+      // first db should still work now
+      const data = generateRandomData(
+        await sqLiteManager.getGeneralSchema(dbFirst), 10);
+      await sqLiteManager.addData(dbFirst, data);
+      const loadedData = (await sqLiteManager.getData(dbFirst)).data;
+      chai.assert.sameDeepMembers(data, loadedData);
     });
 
     it("should be rejected in invalid schema column names", function() {
@@ -338,12 +315,12 @@ describe("sqlite-manager", function() {
       return sqLiteManager.createDataset(dbMem, validSchema).should.be.rejected;
     });
 
-    it("should fail if data table already exists", function() {
-      return dbMem.runAsync(`CREATE TABLE ${sqliteConstants.DATABASE_DATA_TABLE_NAME}(a,b)`, [])
-        .then(() => {
-          return sqLiteManager.createDataset(dbMem, tdxSchemaList.TDX_SCHEMA_LIST[0]);
-        })
-        .should.be.rejected;
+    it("should fail if data table already exists", async () => {
+      await dbMem.runAsync(
+        `CREATE TABLE ${sqliteConstants.DATABASE_DATA_TABLE_NAME}(a,b)`, []);
+      //console.log(await sqLiteManager.getGeneralSchema(dbMem));
+      return sqLiteManager.createDataset(
+        dbMem, tdxSchemaList.TDX_SCHEMA_LIST[0]).should.be.rejected;
     });
 
     it("should save the general schema", function() {
@@ -355,7 +332,7 @@ describe("sqlite-manager", function() {
             return sqLiteManager.createDataset(dbIter, entry);
           })
           .then(() => {
-            return Promise.resolve(sqLiteManager.getGeneralSchema(dbIter));
+            return sqLiteManager.getGeneralSchema(dbIter);
           })
           .should.eventually.deep.equal(entry.generalSchema);
       });
@@ -373,8 +350,8 @@ describe("sqlite-manager", function() {
             dbIter = db;
             return sqLiteManager.createDataset(dbIter, entry);
           })
-          .then(() => {
-            const generalSchema = sqLiteManager.getGeneralSchema(dbIter);
+          .then(async () => {
+            const generalSchema = await sqLiteManager.getGeneralSchema(dbIter);
             const data = generateRandomData(generalSchema, 1000);
             dataSize = data.length;
             return sqLiteManager.addData(dbIter, data);
@@ -469,8 +446,8 @@ describe("sqlite-manager", function() {
           dbIter = db;
           return sqLiteManager.createDataset(dbIter, entry);
         })
-        .then(() => {
-          const generalSchema = sqLiteManager.getGeneralSchema(dbIter);
+        .then(async () => {
+          const generalSchema = await sqLiteManager.getGeneralSchema(dbIter);
           testData = generateRandomData(generalSchema, 1);
 
           return sqLiteManager.addData(dbIter, testData);
@@ -506,8 +483,8 @@ describe("sqlite-manager", function() {
           dbIter = db;
           return sqLiteManager.createDataset(dbIter, entry);
         })
-        .then(() => {
-          const generalSchema = sqLiteManager.getGeneralSchema(dbIter);
+        .then(async () => {
+          const generalSchema = await sqLiteManager.getGeneralSchema(dbIter);
           testData = generateRandomData(generalSchema, dataSize);
 
           return sqLiteManager.addData(dbIter, testData);
@@ -533,8 +510,8 @@ describe("sqlite-manager", function() {
           dbIter = db;
           return sqLiteManager.createDataset(dbIter, entry);
         })
-        .then(() => {
-          const generalSchema = sqLiteManager.getGeneralSchema(dbIter);
+        .then(async () => {
+          const generalSchema = await sqLiteManager.getGeneralSchema(dbIter);
           testData = generateRandomData(generalSchema, dataSize);
 
           return sqLiteManager.addData(dbIter, testData);
@@ -561,8 +538,8 @@ describe("sqlite-manager", function() {
           dbIter = db;
           return sqLiteManager.createDataset(dbIter, entry);
         })
-        .then(() => {
-          const generalSchema = sqLiteManager.getGeneralSchema(dbIter);
+        .then(async () => {
+          const generalSchema = await sqLiteManager.getGeneralSchema(dbIter);
           testData = generateRandomData(generalSchema, dataSize);
 
           return sqLiteManager.addData(dbIter, testData);
@@ -638,8 +615,8 @@ describe("sqlite-manager", function() {
           dbIter = db;
           return sqLiteManager.createDataset(dbIter, entry);
         })
-        .then(() => {
-          generalSchema = sqLiteManager.getGeneralSchema(dbIter);
+        .then(async () => {
+          generalSchema = await sqLiteManager.getGeneralSchema(dbIter);
           testData = generateRandomData(generalSchema, 100);
           return sqLiteManager.addData(dbIter, testData);
         })
@@ -673,8 +650,9 @@ describe("sqlite-manager", function() {
           dbIter = db;
           return sqLiteManager.createDataset(dbIter, entry);
         })
-        .then(() => {
-          writeData = generateRandomData(sqLiteManager.getGeneralSchema(dbIter), 1);
+        .then(async () => {
+          writeData = generateRandomData(
+            await sqLiteManager.getGeneralSchema(dbIter), 1);
           return sqLiteManager.addData(dbIter, writeData);
         })
         .then(() => {
@@ -707,8 +685,8 @@ describe("sqlite-manager", function() {
             dbIter = db;
             return sqLiteManager.createDataset(dbIter, entry);
           })
-          .then(() => {
-            generalSchema = sqLiteManager.getGeneralSchema(dbIter);
+          .then(async () => {
+            generalSchema = await sqLiteManager.getGeneralSchema(dbIter);
             testData = generateRandomData(generalSchema, 100);
 
             return sqLiteManager.addData(dbIter, testData);
@@ -1143,7 +1121,7 @@ describe("sqlite-manager", function() {
       const db = await sqLiteManager.openDatabase("", "memory", "w+");
       await sqLiteManager.createDataset(db, schema);
       const randomData = generateRandomData(
-        sqLiteManager.getGeneralSchema(db), 10);
+        await sqLiteManager.getGeneralSchema(db), 10);
       testData = testData.concat(randomData);
       await sqLiteManager.addData(db, testData);
       await sqLiteManager.deleteData(db, []);


### PR DESCRIPTION
Fixes #32.

Involves a breaking change to the API, as `getGeneralSchema()` now returns a `Promise`.

Instead of `set`/`getGeneralSchema()` storing the schema in a fake singleton object, now the schema is stored in the `db` object, and it is generated lazily (_i.e._ only when needed). However, as it is generated lazily, it needs to be an `async` function.

This means we need to up the `major` version number to `0.7.0`.

I've also added a Changelog so that we can we easily see changes to the API. Thanks to @TobyEalden for giving me the idea in <https://github.com/nqminds/nqm-api-tdx/blob/master/CHANGELOG.md>