### PR TITLE
Allow adding rows with extra columns in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to
 - Error when attempting to addData with columns not in schema.
   Now just raises a warning.
 
-## 0.7.0
+## [0.7.0] - 2019-08-29
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
-### MAJOR
+### Fixed
+
+- Error when attempting to addData with columns not in schema.
+  Now just raises a warning.
+
+## 0.7.0
+
+### Changed
 
 - Changes `getData()` to limit the `limit` field to 1000.
   Also, when `limit === 0`, the default `limit` of 1000 is used.

--- a/lib/sqlite-manager.js
+++ b/lib/sqlite-manager.js
@@ -33,7 +33,6 @@ module.exports = (function() {
   const sqliteNdarray = require("./sqlite-ndarray.js");
 
   const manager = {};
-  const generalSchema = {};
   const queryLimit = sqliteConstants.SQLITE_QUERY_LIMIT;
 
   Promise.promisifyAll(sqlite3);
@@ -59,7 +58,7 @@ module.exports = (function() {
   /**
    * A row of data, with `{columnname: rowvalue}`.
    * @global
-   * @typedef {{string: any}} DataRow
+   * @typedef {{[columnName: string]: any}} DataRow
    */
 
   /**
@@ -79,6 +78,35 @@ module.exports = (function() {
    * @property  {array} result.commit - Contains details of each
    *     committed document.
    */
+
+  /**
+   * Picks specific columns from an object if they exist.
+   * @param {Object<string, any>} obj
+   * @param {Array<string>} columns A list of columns to pick if they exist.
+   * @returns {Object<string, any>}
+   *   The input object with only keys in `columns`.
+   */
+  function pick(obj, columns) {
+    return columns.reduce(
+      (res, key) => {
+        const value = obj[key];
+        if (value !== undefined) {
+          res[key] = obj[key];
+        }
+        return res;
+      },
+      {},
+    );
+  }
+
+  const warnedAlready = new Set();
+  function warn(warning, name, code) {
+    if (warnedAlready.has(code)) {
+      return; // only warn once per process
+    }
+    warnedAlready.add(code);
+    process.emitWarning(warning, name, code);
+  }
 
   /**
    * Makes an empty {@link CommandResult}
@@ -465,13 +493,28 @@ module.exports = (function() {
     const schema = await manager.getGeneralSchema(db);
     const dataToConvert = [].concat(data);
 
+    // remove extra columns in data that aren't in the schema
+    const onlySchemaColumns = dataToConvert.map((row) => {
+      const onlySchemaColumnRow = pick(row, Object.keys(schema));
+      if (Object.keys(row).length !== Object.keys(onlySchemaColumnRow).length) {
+        warn("Ignoring extra fields in row that were not in schema. " +
+          `Row was: ${JSON.stringify(row)} and extra keys were: ` +
+          Object.keys(row).filter((col) => schema[col] === undefined),
+          "ExtraFields", "AddDataExtraFields",
+        );
+      }
+      return onlySchemaColumnRow;
+    });
+
     // Get the ndarray keys
-    const ndarrayKeys = findCollectionKeys(schema, sqliteConstants.SQLITE_GENERAL_TYPE_NDARRAY);
+    const ndarrayKeys = findCollectionKeys(
+      schema, sqliteConstants.SQLITE_GENERAL_TYPE_NDARRAY);
 
     // Save the ndarray data to file
-    let arrayProcData = dataToConvert;
+    let arrayProcData = onlySchemaColumns;
     if (ndarrayKeys. length > 0)
-      arrayProcData = await sqliteNdarray.writeNdarrayMany(db, dataToConvert, ndarrayKeys);
+      arrayProcData = await sqliteNdarray.writeNdarrayMany(
+        db, onlySchemaColumns, ndarrayKeys);
 
     // convert all the data to SQLite types
     const sqlData = arrayProcData.map((row) => {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "start": "",
-    "test": "mocha",
+    "test": "mocha --no-warnings",
     "lint": "eslint client && echo \"eslint: no lint errors\"",
     "jsdocs": "jsdoc -c jsdoc-config.json",
     "docs": "npm run api-md && TZ=UTC npm run jsdocs",

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,5 +1,32 @@
 const fs = require("fs");
 
+/**
+ * Adapted from
+ * https://github.com/nodejs/node/blob/master/lib/internal/process/warning.js
+ */
+exports.onWarning = (warning) => {
+  if (!(warning instanceof Error)) return;
+  const isDeprecation = warning.name === 'DeprecationWarning';
+  if (isDeprecation) return;
+  const trace = (isDeprecation && process.traceDeprecation);
+  let msg = `(${process.release.name}:${process.pid}) `;
+  if (warning.code)
+    msg += `[${warning.code}] `;
+  if (trace && warning.stack) {
+    msg += `${warning.stack}`;
+  } else {
+    const toString =
+      typeof warning.toString === 'function' ?
+        warning.toString : Error.prototype.toString;
+    msg += `${toString.apply(warning)}`;
+  }
+  if (typeof warning.detail === 'string') {
+    msg += `\n${warning.detail}`;
+  }
+  console.warn(msg);
+};
+process.on("warning", exports.onWarning); // print warnings to console
+
 exports.deleteFile = function(name) {
   try {
     fs.unlinkSync(name);


### PR DESCRIPTION
Previously, adding a row with a column that wasn't in the
schema failed with a confusing error.

It now ignores the extra column, printing out a warning
in the first instance only.

This is a FIXED change, i.e. a bugfix version update. (up from x.y.0 to x.y.1)