### PR TITLE
Remove dependency on temp-dir library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - Updated minimum version of Node to v10.12.0,
   for `fs.mkdir`'s `recursive: true` option.
 
+### Fixed
+- Removed dependency on
+  [`temp-dir`](https://www.npmjs.com/package/temp-dir) (#39).
+
 ## [0.7.2] - 2019-10-02
 
 ### Changed

--- a/lib/sqlite-manager.js
+++ b/lib/sqlite-manager.js
@@ -20,8 +20,8 @@ const builder = require("mongo-sql");
 // node.js built-in
 const util = require("util");
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
-const tempDir = require("temp-dir");
 
 const sqliteConstants = require("./sqlite-constants.js");
 const sqliteInfoTable = require("./sqlite-info-table.js");
@@ -219,6 +219,7 @@ module.exports.openDatabase = async function(filepath, type, mode) {
     dataFolderPath = join(dirname(databasePath), dataFolderName);
   } else if (type === sqliteConstants.DATABASE_MEMORY_TYPE) {
     const dataFolderName = sqliteConstants.DATABASE_DATA_TMP_NAME + sqliteConstants.DATABASE_FOLDER_SUFFIX;
+    const tempDir = fs.realpathSync(os.tmpdir());
     dataFolderPath = join(tempDir, dataFolderName);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2708,11 +2708,6 @@
         "yallist": "^3.0.3"
       }
     },
-    "temp-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
-    },
     "temp-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "path": "^0.12.7",
     "semver": "^6.3.0",
     "shortid": "^2.2.15",
-    "sqlite3": "^4.0.4",
-    "temp-dir": "^1.0.0"
+    "sqlite3": "^4.0.4"
   },
   "private": false,
   "babel": {

--- a/test/test-sqlite-manager.js
+++ b/test/test-sqlite-manager.js
@@ -3,6 +3,8 @@
 
 const path = require("path");
 const fs = require("fs");
+const os = require("os");
+
 const _ = require("lodash");
 const del = require("del");
 const Promise = require("bluebird");
@@ -10,10 +12,10 @@ const chai = require("chai");
 const chaiAsPromised = require("chai-as-promised");
 const deepEqualInAnyOrder = require("deep-equal-in-any-order");
 const shortid = require("shortid");
-const tempDir = require("temp-dir");
 const sqLiteManager = require("../lib/sqlite-manager.js");
 const sqliteInfoTable = require("../lib/sqlite-info-table.js");
 const sqliteNdarray = require("../lib/sqlite-ndarray.js");
+
 // @ts-ignore
 const packageJson = require("../package.json");
 const helper = require("./helper.js");
@@ -23,6 +25,7 @@ const tdxSchemaList = require("./tdx-schema-list.js");
 const testTimeout = 20000;
 
 let dbMem;
+const tempDir = fs.realpathSync(os.tmpdir());
 
 let databasePath = process.argv[1];
 const projectNameIdx = databasePath.indexOf(packageJson.name);


### PR DESCRIPTION
Replaces with `fs.realpathSync(os.tmpdir())`

Closes #39.